### PR TITLE
Ability to edit markdown using stackedit.js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,8 @@
         "react-markdown": "6.0.3",
         "react-router-dom": "^5.3.0",
         "react-scripts": "^4.0.3",
-        "rehype-highlight": "5.0.0"
+        "rehype-highlight": "5.0.0",
+        "stackedit-js": "^1.0.7"
       },
       "devDependencies": {
         "@babel/runtime": "7.13.8",
@@ -18769,6 +18770,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/stackedit-js": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/stackedit-js/-/stackedit-js-1.0.7.tgz",
+      "integrity": "sha512-FG2MNncXlSEscwBa3Ih6Xl1zrbeJ8/vgbrbzwwLvkdgFIMCRZQzpFpqxSW2o/1AvxguhXrt2dml/Z/I1m5eoLg==",
+      "engines": {
+        "node": ">= 8.0.0",
+        "npm": ">= 5.0.0"
+      }
+    },
     "node_modules/stackframe": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.2.0.tgz",
@@ -36568,6 +36578,11 @@
           "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="
         }
       }
+    },
+    "stackedit-js": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/stackedit-js/-/stackedit-js-1.0.7.tgz",
+      "integrity": "sha512-FG2MNncXlSEscwBa3Ih6Xl1zrbeJ8/vgbrbzwwLvkdgFIMCRZQzpFpqxSW2o/1AvxguhXrt2dml/Z/I1m5eoLg=="
     },
     "stackframe": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "react-markdown": "6.0.3",
     "react-router-dom": "^5.3.0",
     "react-scripts": "^4.0.3",
-    "rehype-highlight": "5.0.0"
+    "rehype-highlight": "5.0.0",
+    "stackedit-js": "^1.0.7"
   },
   "devDependencies": {
     "@babel/runtime": "7.13.8",

--- a/src/components/EmbeddedIDE.js
+++ b/src/components/EmbeddedIDE.js
@@ -1,6 +1,3 @@
-import React from "react"
-import "./EmbeddedIDE.css";
-
 function EmbeddedIDE(props) {
     const defaultStyle = { width: "100%", height: "100%", border: "none" };
 

--- a/src/components/Markdown.js
+++ b/src/components/Markdown.js
@@ -1,0 +1,49 @@
+import Stackedit from "stackedit-js"
+import ReactMarkdown from "react-markdown"
+import rehypeHighlight from "rehype-highlight"
+import { useState } from "react"
+
+import Fab from "@material-ui/core/Fab"
+import EditIcon from "@material-ui/icons/Edit"
+
+import "highlight.js/styles/base16/zenburn.css"
+
+function Markdown(props) {
+    const [markdown, setMarkdown] = useState(props.markdown);
+    
+    const openStackedit = () => {
+        const stackedit = new Stackedit()
+        stackedit.openFile({
+            name: "filename",
+            content: {
+                text: markdown
+            }
+        })
+
+        stackedit.on("fileChange", (file) => {
+            setMarkdown(file.content.text)
+        })
+
+        stackedit.on("close", () => {
+            // TODO when user closes modal, post to backend to save changes
+        })
+    }
+
+    return (
+        <div>
+            {props.canEdit &&
+                <Fab color="primary" style={{float: "right", right: "10px"}} onClick={openStackedit}>
+                    <EditIcon/>
+                </Fab>
+            }
+            <div>
+                <ReactMarkdown
+                    children={markdown}
+                    rehypePlugins={[rehypeHighlight]}>
+                </ReactMarkdown>
+            </div>
+        </div>
+    )
+}
+
+export default Markdown

--- a/src/modules/LearningModule.js
+++ b/src/modules/LearningModule.js
@@ -1,14 +1,13 @@
-import React from "react";
-import ReactMarkdown from "react-markdown";
-import rehypeHighlight from "rehype-highlight";
-import EmbeddedIDE from "../components/EmbeddedIDE/EmbeddedIDE";
-import "./LearningModule.css";
+import React from "react"
+import EmbeddedIDE from "../components/EmbeddedIDE"
+import Markdown from "../components/Markdown"
+import "./LearningModule.css"
 
 import { Link, useParams } from "react-router-dom"
 import { Button } from "@material-ui/core"
 import { ArrowBack } from "@material-ui/icons"
 
-import 'highlight.js/styles/base16/zenburn.css'
+import "highlight.js/styles/base16/zenburn.css"
 import "./LearningModule.css"
 import ModuleData from "../data/ModuleData"
 
@@ -29,12 +28,9 @@ function LearningModule() {
                         </Button>
                     </Link>
                 </div>
-                <div style={{ display: "flex", height: '800px'}}>
+                <div style={{ display: "flex", height: "800px"}}>
                     <div className="lm-leftcolumn">
-                        <ReactMarkdown
-                            children={moduleDatum.markdown}
-                            rehypePlugins={[rehypeHighlight]}>
-                        </ReactMarkdown>
+                        <Markdown markdown={moduleDatum.markdown} canEdit={true}/>
                     </div>
                     <div className="lm-rightcolumn">
                         <EmbeddedIDE embedURL={moduleDatum.embeddedIDEURL} customIFrameStyle={moduleDatum.embedIDEStyle}/>


### PR DESCRIPTION
I've created a reusable Markdown component that combines the best of both react-markdown and stackedit.js. I couldn't use just stackedit.js since it doesn't have options for read-only display of markdown. But it does provide powerful WYSIWYG editing. So we still need to display the markdown as read-only using react-markdown. And we can allow users to edit the markdown using an embedded Stackedit iframe (courtesy of stackedit.js). The ability to edit is toggleable, since we will only want to give certain users the ability to edit. 